### PR TITLE
Return ID when adding

### DIFF
--- a/tikapy/__init__.py
+++ b/tikapy/__init__.py
@@ -171,7 +171,7 @@ class TikapyBaseClient():
         Send command sequence to the API.
 
         :param words: List of command sequences to send to the API
-        :returns: dict containing response.
+        :returns: dict containing response or ID.
         :raises: ClientError - If client could not talk to remote API.
                  ValueError - On invalid input.
         """
@@ -188,8 +188,13 @@ class TikapyBaseClient():
         Converts MikroTik RouterOS output to python dict / JSON.
 
         :param tikoutput:
-        :return: doct containing response.
+        :return: dict containing response or ID.
         """
+        try:
+            if tikoutput[0][0] == '!done':
+                return tikoutput[0][1]['ret']
+        except (IndexError, KeyError):
+            pass
         try:
             return {
                 d['.id'][1:]: d for d in ([x[1] for x in tikoutput])


### PR DESCRIPTION
Some RouterOS API commands return a value in the !done sentence.
This is useful when you need to work with records you have just added.

The current behavior is to return an empty dictionary:

```
>>> client.talk(['/ip/firewall/address-list/add', '=address=5.6.7.8', '=list=test'])
{}
```

I would like the talk function to return the ID:

```
>>> client.talk(['/ip/firewall/address-list/add', '=address=5.6.7.8', '=list=test'])
'*1AA'
```
