### PR TITLE
Bump SSL security settings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,14 +7,14 @@ This project adheres to `Semantic Versioning`_.
 `Unreleased`_
 -------------
 
-`0.2.1`_ - 2015-06-11
----------------------
-
 Changed
 ~~~~~~~
 
 - TLS certificates are now checked against system CA store, and matched against
   the provided hostname.
+
+`0.2.1`_ - 2015-06-11
+---------------------
 
 Fixed
 ~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,8 @@ This project adheres to `Semantic Versioning`_.
 Changed
 ~~~~~~~
 
-- TLS certificates are now checked against system CA store.
+- TLS certificates are now checked against system CA store, and matched against
+  the provided hostname.
 
 Fixed
 ~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,11 @@ This project adheres to `Semantic Versioning`_.
 `0.2.1`_ - 2015-06-11
 ---------------------
 
+Changed
+~~~~~~~
+
+- TLS certificates are now checked against system CA store.
+
 Fixed
 ~~~~~
 

--- a/tikapy/__init__.py
+++ b/tikapy/__init__.py
@@ -225,18 +225,21 @@ class TikapySslClient(TikapyBaseClient):
     RouterOS SSL API Client.
     """
 
-    def __init__(self, address, port=8729, verify_cert=True):
+    def __init__(self, address, port=8729, verify_cert=True,
+                 verify_addr=True):
         """
         Initialize client.
 
         :param address: Remote device address (maybe a hostname)
         :param port: Remote device port (defaults to 8728)
         :param verify_cert: Verify device certificate against system CAs
+        :param verify_addr: Verify provided address against certificate
         """
         super().__init__()
         self.address = address
         self.port = port
         self.verify_cert = verify_cert
+        self.verify_addr = verify_addr
 
     def _connect(self):
         """
@@ -247,7 +250,10 @@ class TikapySslClient(TikapyBaseClient):
             ctx = ssl.create_default_context()
             if not self.verify_cert:
                 ctx.verify_mode = ssl.CERT_OPTIONAL
-            self._sock = ctx.wrap_socket(self._base_sock)
+            if not self.verify_addr:
+                ctx.check_hostname = False
+            self._sock = ctx.wrap_socket(self._base_sock,
+                                         server_hostname=self.address)
         except ssl.SSLError:
             LOG.error('could not establish SSL connection')
             raise ClientError('could not establish SSL connection')

--- a/tikapy/__init__.py
+++ b/tikapy/__init__.py
@@ -225,16 +225,18 @@ class TikapySslClient(TikapyBaseClient):
     RouterOS SSL API Client.
     """
 
-    def __init__(self, address, port=8729):
+    def __init__(self, address, port=8729, verify_cert=True):
         """
         Initialize client.
 
         :param address: Remote device address (maybe a hostname)
         :param port: Remote device port (defaults to 8728)
+        :param verify_cert: Verify device certificate against system CAs
         """
         super().__init__()
         self.address = address
         self.port = port
+        self.verify_cert = verify_cert
 
     def _connect(self):
         """
@@ -242,7 +244,10 @@ class TikapySslClient(TikapyBaseClient):
         """
         self._connect_socket()
         try:
-            self._sock = ssl.wrap_socket(self._base_sock)
+            ctx = ssl.create_default_context()
+            if not self.verify_cert:
+                ctx.verify_mode = ssl.CERT_OPTIONAL
+            self._sock = ctx.wrap_socket(self._base_sock)
         except ssl.SSLError:
             LOG.error('could not establish SSL connection')
             raise ClientError('could not establish SSL connection')


### PR DESCRIPTION
This tells Python to set the preferred options, use system CA store, and optionally verify the provided hostname against certificate.