### PR TITLE
Nonchap auth and others

### DIFF
--- a/tikapy/__init__.py
+++ b/tikapy/__init__.py
@@ -217,32 +217,7 @@ class TikapyBaseClient():
                 if '.id' in d.keys()}
         except (TypeError, IndexError) as exc:
             raise ClientError('unable to convert api output to json') from exc
-
-    def _api_talk(self, words):
-        """
-        Send command sequence to the API. - See to update tik_to_json
-        so that you can remove ths function.
-
-        :param words: List of command sequences to send to the API
-        :returns: list containing response or ID. Includes responses pm
-        more advanced Mikrotik commands.
-        :raises: ClientError - If client could not talk to remote API.
-                 ValueError - On invalid input.
-        """
-        if isinstance(words, list) and all(isinstance(x, str) for x in words):
-            try:
-                result = []
-                feedback = self._api.talk(words)
-                for feed in feedback:
-                    temp = ""
-                    for temp in feed:
-                        if temp and isinstance(temp, dict):
-                            result.append(temp)
-                return result
-            except (ApiError, ApiUnrecoverableError) as exc:
-                raise ClientError('could not talk to api') from exc
-        raise ValueError('words needs to be a list of strings')
-        
+       
 
 class TikapyClient(TikapyBaseClient):
     """


### PR DESCRIPTION
## Overview

### What is the feature / changes?
Changes to how Mikrotik's save passwords on the device has caused that the method of authentication has changed. This is since RouterOS version 6.43rc19 and newer. I have also added a timeOut parameter for the login to set the timeout time for the connection to the device. Also added a specific cipher for the login attempt using TikapySslClient due to issues with SSLv3 experienced.

Almost all of the authentication changes were taken from the update added by @grawity.

### What areas of the application does it impact?
The login and authentication section of the package has been changed.

## Testing

### What's required testing?
A device with a with the RouterOS version lower than 6.43rc19 and one at 6.43rc19 or higher. Then attempt to login onto the device.